### PR TITLE
Revert "selinux: Relocate ss_initialized and selinux_enforcing to separate 4k"

### DIFF
--- a/arch/arm64/kernel/vmlinux.lds.S
+++ b/arch/arm64/kernel/vmlinux.lds.S
@@ -76,10 +76,7 @@ jiffies = jiffies_64;
 #define TRAMP_TEXT
 #endif
 
-#define RTIC_BSS					\
-	. = ALIGN(PAGE_SIZE);				\
-	KEEP(*(.bss.rtic));			\
-	. = ALIGN(PAGE_SIZE);				\
+
 /*
  * The size of the PE/COFF section that covers the kernel image, which
  * runs from stext to _edata, must be a round multiple of the PE/COFF
@@ -260,10 +257,6 @@ SECTIONS
 	STABS_DEBUG
 
 	HEAD_SYMBOLS
-
-	.bss : {			/* bss segment		*/
-         RTIC_BSS
-	}
 }
 
 /*

--- a/include/linux/init.h
+++ b/include/linux/init.h
@@ -322,8 +322,6 @@ void __init parse_early_options(char *cmdline);
 /* Data marked not to be saved by software suspend */
 #define __nosavedata __section(.data..nosave)
 
-#define __rticdata  __attribute__((section(".bss.rtic")))
-
 #ifdef MODULE
 #define __exit_p(x) x
 #else

--- a/kernel/sysctl.c
+++ b/kernel/sysctl.c
@@ -134,6 +134,7 @@ static unsigned long one_ul = 1;
 static unsigned long long_max = LONG_MAX;
 static int one_hundred = 100;
 static int one_thousand = 1000;
+static int max_swappiness = 200;
 #ifdef CONFIG_PRINTK
 static int ten_thousand = 10000;
 #endif
@@ -1725,7 +1726,7 @@ static struct ctl_table vm_table[] = {
 		.mode		= 0644,
 		.proc_handler	= proc_dointvec_minmax,
 		.extra1		= &zero,
-		.extra2		= &one_hundred,
+		.extra2		= &max_swappiness,
 	},
 	{
 		.procname       = "want_old_faultaround_pte",

--- a/security/selinux/hooks.c
+++ b/security/selinux/hooks.c
@@ -100,7 +100,7 @@
 #include "audit.h"
 #include "avc_ss.h"
 
-struct selinux_state selinux_state __rticdata;
+struct selinux_state selinux_state;
 
 /* SECMARK reference count */
 static atomic_t selinux_secmark_refcount = ATOMIC_INIT(0);


### PR DESCRIPTION
This reverts commit https://github.com/libxzr/android_kernel_oneplus_sm8250/commit/50240fa8416f5fd183cb147fd3c66aeaeb74a1f8.

That out of tree patch causes the resulting kernel image to be too
large, causing ld.lld to error; since .bss is specified twice.

Fixes the observed error:
ld.lld: error: output file too large: 18446743524330100280 bytes

when using LLD without LTO enabled.

Bug: 151154720
Reported-by: Matthias Maennich <maennich@google.com>
Debugged-by: Fangrui Song <maskray@google.com>
Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
Change-Id: Iebb8135630132cd4ae49f3d2d1e85bd61cfa6111